### PR TITLE
Waiting to measure after second requestAnimationFrame

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,6 +14,7 @@ export default class ReadMore extends React.Component {
 
   async componentDidMount() {
     await nextFrameAsync();
+    await nextFrameAsync();
 
     // Get the height of the text with no restriction on number of lines
     const fullHeight = await measureHeightAsync(this._text);


### PR DESCRIPTION
Sometimes after the first requestAnimationFrame the view measures 0. So calling measure after the second requestAnimationFrame