### PR TITLE
Invoke onReady callback also when the height of the text does not exceed the limit

### DIFF
--- a/index.js
+++ b/index.js
@@ -27,6 +27,8 @@ export default class ReadMore extends React.Component {
       this.setState({shouldShowReadMore: true}, () => {
         this.props.onReady && this.props.onReady();
       });
+    } else {
+      this.props.onReady && this.props.onReady();
     }
   }
 


### PR DESCRIPTION
Currently, onReady callback is invoked only when fullHeight is greater than limitedHeight.
Invoke onReady callback also when the height of the text does not exceed the limit, because the component is ready at that point as well.