### PR TITLE
Fix unhandled promise rejection

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,12 +13,21 @@ export default class ReadMore extends React.Component {
   }
 
   async componentDidMount() {
+    this._isMounted = true
     await nextFrameAsync();
+
+    if(!this._isMounted) {
+      return
+    }
 
     // Get the height of the text with no restriction on number of lines
     const fullHeight = await measureHeightAsync(this._text);
     this.setState({measured: true});
     await nextFrameAsync();
+
+    if(!this._isMounted) {
+      return
+    }
 
     // Get the height of the text now that number of lines has been set
     const limitedHeight = await measureHeightAsync(this._text);
@@ -28,6 +37,10 @@ export default class ReadMore extends React.Component {
         this.props.onReady && this.props.onReady();
       });
     }
+  }
+
+  componentWillUnmount() {
+    this._isMounted = false
   }
 
   render() {


### PR DESCRIPTION
**Resolves:** https://github.com/expo/react-native-read-more-text/issues/4

Fix unhandled promise rejection (TypeError: Cannot read property 'measure' of null).

The error happens because componentWillUnmount sometimes is invoked before the async componentDidMount finishes (usually before the 2nd measureHeightAsync function is invoked) and at this point, this._text reference is undefined.

Another solution would be to check for this._text instead of this._isMounted, but, according to me, this approach looks more transparent regarding the cause of the issue.