### PR TITLE
Fixed wrong hight measurenment for short strings

### DIFF
--- a/index.js
+++ b/index.js
@@ -100,7 +100,7 @@ export default class ReadMore extends React.Component {
 function measureHeightAsync(component) {
   return new Promise(resolve => {
     component.measure((x, y, w, h) => {
-      resolve(h);
+      resolve(Math.ceil(h));
     });
   });
 }


### PR DESCRIPTION
On ios hight measurenment sometimes is work wrong. 
For example, if i write "Enjoyable salon experience", fullHeight and limitedHeight will be have this value:
fullHeight:  17.6666259765625 limitedHeight:  17.3333740234375

In this case, I have "read more" button, but it should not be.

Using `Math.ceil` in `measureHeightAsync` function solves this problem.

![Screenshot 2019-05-08 at 16 12 50](https://user-images.githubusercontent.com/10216905/57363876-304a4c80-71ac-11e9-9eae-45f762cdd4c0.png)